### PR TITLE
Added property to Symbolics that returns the ground reaction force vector expressions.

### DIFF
--- a/pygait2d/derive.py
+++ b/pygait2d/derive.py
@@ -60,6 +60,8 @@ class Symbolics():
     speeds : list of Function(t)
         The generalized speeds of the system.
     states : list of Function(t)
+    ground_reaction_forces : dictionary
+        Force vectors acting on the right and left foot toe and heel points.
 
     """
     # TODO : Add these as properties.
@@ -163,6 +165,20 @@ class Symbolics():
             return self.specifieds[:-1]
         elif len(self.specifieds) == 10:
             return self.specifieds[3:-1]
+
+    @property
+    def ground_reaction_forces(self):
+        """Returns a dictionary the ground reaction force vectors expressed in
+        the inertial reference frame acting on the heel and toe of each foot.
+        Keys are ``'Right Foot heel', 'Right Foot toe', 'Left Foot heel',
+        'Left Foot toe'``."""
+        grfs = {}
+        for load in self.kanes_method.loads:
+            point_name = load[0].name
+            if point_name in ['Right Foot heel', 'Right Foot toe',
+                              'Left Foot heel', 'Left Foot toe']:
+                grfs[point_name] = load[1]
+        return grfs
 
 
 def generate_gait_cycle_torque_controller(coordinates, speeds, specified):
@@ -424,7 +440,7 @@ def derive_equations_of_motion(
 
         segment_class, desc, joint_desc = segment_descriptions[label]
         passive_torque = passive_torques  # true or false for this particular segment
-        
+
         if label == 'A':  # trunk
             parent_reference_frame = ground
             origin_joint = origin

--- a/pygait2d/utils.py
+++ b/pygait2d/utils.py
@@ -307,14 +307,15 @@ def plot(sym, times, x, r, p, follow=None):
 
     # show ground reaction force vectors at the heels and toes, scaled to
     # visually reasonable length
-    #scene.add_vector(contact_force(rfoot.toe, ground, origin, v)/600.0,
-                        #rfoot.toe, color="tab:blue")
-    #scene.add_vector(contact_force(rfoot.heel, ground, origin, v)/600.0,
-                        #rfoot.heel, color="tab:blue")
-    #scene.add_vector(contact_force(lfoot.toe, ground, origin, v)/600.0,
-                        #lfoot.toe, color="tab:blue")
-    #scene.add_vector(contact_force(lfoot.heel, ground, origin, v)/600.0,
-                        #lfoot.heel, color="tab:blue")
+    grf = sym.ground_reaction_forces
+    scene.add_vector(grf['Right Foot toe']/600.0, rfoot.toe,
+                     color="tab:blue")
+    scene.add_vector(grf['Right Foot heel']/600.0, rfoot.heel,
+                     color="tab:blue")
+    scene.add_vector(grf['Left Foot toe']/600.0, lfoot.toe,
+                     color="tab:blue")
+    scene.add_vector(grf['Left Foot heel']/600.0, lfoot.heel,
+                     color="tab:blue")
 
     scene.lambdify_system(sym.states + sym.specifieds + sym.constants)
     scene.evaluate_system(*np.hstack((x, r, p)))


### PR DESCRIPTION
@tvdbogert this will at least make the current force expressions more easily accessible. Then it is only a matter of copying the approach for marker tracking but with these values. Of course, it is not the approach of separating the forces from the dynamics model.

You can do this to get expressions for each component:

```python
symbolics.ground_reaction_forces['Right Foot toe'].to_matrix(symbolics.inertial_frame)
```